### PR TITLE
Removes R2-D2 override

### DIFF
--- a/overrides.json
+++ b/overrides.json
@@ -16,9 +16,6 @@
     "ept" : {
       "adaptabilityflippable" : "adaptability"
     },
-    "amd" : {
-      "r2d2":"r2d2swx22"
-    },
     "title" : {
       "milleniumfalcon" : "millenniumfalcon",
       "milleniumfalcon2" : "millenniumfalcon2",


### PR DESCRIPTION
The card name was fixed in this commit in the image repository and the override is no longer needed.
https://github.com/voidstate/xwing-card-images/commit/7658d8959c16d7c0330eb4b50ae4c7d3024b89a3